### PR TITLE
fixing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ env:
   - TOXENV=py33
   - TOXENV=py34
 
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+
 install:
   - pip install tox
   - if [[ "${TOXENV}" == "py32" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - TOXENV=py34
 
 install:
-  - "pip install tox --use-mirrors"
-
+  - pip install tox
+  - if [[ "${TOXENV}" == "py32" ]]; then
+      pip install "virtualenv<14.0" ;
+    fi
 script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.5
+requests>=2.5,<2.11.0
 six>=1.9
 pycrypto>=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
           'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python',
           'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34, py35
 
 [testenv]
 deps =


### PR DESCRIPTION
I was playing around with the coinbase-python client and noticed that the 3.2 build hasn't been working because Virtualenv 14.0+ is now enforcing python 3.2 deprecation. Requests also dropped support for python 3.2 a couple of years ago, but didn't have any conflicts until 2.11.0. I removed `--use-mirrors` as well because pypa hasn't supported it since 7.0.

These two changes will fix the build issues, but it may be worth considering deprecating 3.2 support in the future since this package's dependencies and most of the community is moving towards that.

I also added 3.5 to supported versions because it's a freebie with 3.3 and 3.4 support. I can drop  13041c4 if you'd prefer not to add it though.
