### PR TITLE
change API VERSION default in client.py (avoid warnings)

### DIFF
--- a/coinbase/wallet/client.py
+++ b/coinbase/wallet/client.py
@@ -65,7 +65,7 @@ class Client(object):
   VERIFY_SSL = True
 
   BASE_API_URI = 'https://api.coinbase.com/'
-  API_VERSION = '2016-02-18'
+  API_VERSION = '2016-08-10'
 
   cached_callback_public_key = None
 


### PR DESCRIPTION
As proposed in #30, to accommodate client price queries of other currency-pairs, for a new release tag to update PYPI. 