### PR TITLE
get_historic_prices accepts a currency pair

### DIFF
--- a/coinbase/wallet/client.py
+++ b/coinbase/wallet/client.py
@@ -205,7 +205,11 @@ class Client(object):
 
   def get_historic_prices(self, **params):
     """https://developers.coinbase.com/api/v2#get-historic-prices"""
-    response = self._get('v2', 'prices', 'historic', data=params)
+    if 'currency_pair' in params:
+      currency_pair = params['currency_pair']
+    else:
+      currency_pair = 'BTC-USD'
+    response = self._get('v2', 'prices', currency_pair, 'historic', data=params)
     return self._make_api_object(response, APIObject)
 
   def get_time(self, **params):


### PR DESCRIPTION
`get_historic_prices` was not accepting a `currency_pair` parameter and as a result would only return BTC-USD prices. I modified it, following the template used in the other functions querying the prices endpoint.