### PR TITLE
Fix AttributeError message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: python
 
 python:
-  - "2.7"
-
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py32
-  - TOXENV=py33
-  - TOXENV=py34
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
 
 install:
-  - "pip install tox --use-mirrors"
+  - "pip install --upgrade pip && pip install tox-travis"
 
 script: tox

--- a/coinbase/wallet/model.py
+++ b/coinbase/wallet/model.py
@@ -80,7 +80,7 @@ class APIObject(dict):
       return dict.__getitem__(self, *args, **kwargs)
     except KeyError as key_error:
       attribute_error = AttributeError(*key_error.args)
-      attribute_error.message = key_error.message
+      attribute_error.message = getattr(key_error, 'message', '')
       raise attribute_error
 
   def __delattr__(self, *args, **kwargs):
@@ -88,7 +88,7 @@ class APIObject(dict):
       return dict.__delitem__(self, *args, **kwargs)
     except KeyError as key_error:
       attribute_error = AttributeError(*key_error.args)
-      attribute_error.message = key_error.message
+      attribute_error.message = getattr(key_error, 'message', '')
       raise attribute_error
 
   def __setattr__(self, key, value):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -65,6 +65,11 @@ class TestAPIObject(unittest2.TestCase):
     # Keys not present originally will not be removed
     self.assertEqual(obj.resource_path, '/resource/foo')
 
+  def test_dot_notation(self):
+    client = Client(api_key, api_secret)
+    obj = new_api_object(client, mock_item, APIObject)
+    with self.assertRaises(AttributeError):
+        obj.foo
 
 mock_account = {
     'id': 'foo',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py33, py34
 
 [testenv]
 deps =
   -rtest-requirements.txt
   -rrequirements.txt
 commands = nosetests --with-coverage --cover-branches --cover-package=coinbase
+
+[travis]
+python =
+  2.6: py26
+  2.7: py27
+  3.3: py33
+  3.4: py34


### PR DESCRIPTION
Previously errors would be reported as `AttributeError: 'KeyError' object has no attribute 'message'`. BaseException.message was deprecated in python 2.6 and was removed in python 2.7 and 3.0 https://www.python.org/dev/peps/pep-0352/

(Had to make some fixes to the travis build to get tests to pass, depends on #53 )