### PR TITLE
Test against python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
+  - 3.6
 
 install:
   - "pip install --upgrade pip && pip install tox-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: python
 
 python:
-  - "2.7"
-
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py32
-  - TOXENV=py33
-  - TOXENV=py34
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
 
 install:
-  - "pip install tox --use-mirrors"
+  - "pip install --upgrade pip && pip install tox-travis"
 
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python',
           'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py33, py34
 
 [testenv]
 deps =
   -rtest-requirements.txt
   -rrequirements.txt
 commands = nosetests --with-coverage --cover-branches --cover-package=coinbase
+
+[travis]
+python =
+  2.6: py26
+  2.7: py27
+  3.3: py33
+  3.4: py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 deps =
@@ -13,3 +13,5 @@ python =
   2.7: py27
   3.3: py33
   3.4: py34
+  3.5: py35
+  3.6: py36


### PR DESCRIPTION
Test against python 3.5 and 3.6 (and drop support for 3.2 since it's [not supported by the `requests` library](https://github.com/requests/requests/issues/3479))

Depends on #53 