### PR TITLE
Added currency and payment_method params as required to the buy method

### DIFF
--- a/coinbase/wallet/client.py
+++ b/coinbase/wallet/client.py
@@ -404,6 +404,9 @@ class Client(object):
     """https://developers.coinbase.com/api/v2#buy-bitcoin"""
     if 'amount' not in params and 'total' not in params:
       raise ValueError("Missing required parameter: 'amount' or 'total'")
+    for required in ['currency', 'payment_method']:
+      if required not in params:
+        raise ValueError("Missing required parameter: %s" % required)
     response = self._post('v2', 'accounts', account_id, 'buys', data=params)
     return self._make_api_object(response, Buy)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -492,7 +492,7 @@ class TestClient(unittest2.TestCase):
     client = Client(api_key, api_secret)
     with self.assertRaises(ValueError):
       client.buy('foo')
-    for valid_kwargs in [{'amount': '1.0'}, {'total': '1.0'}]:
+    for valid_kwargs in [{'amount': '1.0', 'payment_method': 'bar', 'currency': 'USD'}, {'total': '1.0', 'payment_method': 'bar', 'currency': 'USD'}]:
       buy = client.buy('foo', **valid_kwargs)
       self.assertIsInstance(buy, Buy)
       self.assertEqual(buy, mock_item)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -272,7 +272,7 @@ class TestAccount(unittest2.TestCase):
     account = new_api_object(client, mock_account, Account)
     with self.assertRaises(ValueError):
       account.buy()
-    for valid_kwargs in [{'amount': '1.0'}, {'total': '1.0'}]:
+    for valid_kwargs in [{'amount': '1.0', 'payment_method': 'bar', 'currency': 'USD'}, {'total': '1.0', 'payment_method': 'bar', 'currency': 'USD'}]:
       buy = account.buy(**valid_kwargs)
       self.assertIsInstance(buy, Buy)
       self.assertEqual(buy, mock_item)


### PR DESCRIPTION
The 'currency' param is required by the API endpoint, while the 'payment_method' param is not, but should be to avoid unintended funding from linked accounts.

Updated the unit tests to support the additional required params.