### PR TITLE
Retrieve resource_path from response and apply to APIObject

### DIFF
--- a/coinbase/wallet/compat.py
+++ b/coinbase/wallet/compat.py
@@ -3,10 +3,10 @@ import six
 if six.PY2:
     from itertools import imap
     from urllib import quote
-    from urlparse import urljoin
+    from urlparse import urljoin, urlsplit
     from urlparse import urlparse
 elif six.PY3:
     imap = map
     from urllib.parse import quote
-    from urllib.parse import urljoin
+    from urllib.parse import urljoin, urlsplit
     from urllib.parse import urlparse

--- a/coinbase/wallet/model.py
+++ b/coinbase/wallet/model.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 import json
 import six
 
+from coinbase.wallet.compat import urlsplit
+
 
 def new_api_object(client, obj, cls=None, **kwargs):
     if isinstance(obj, dict):
@@ -38,12 +40,15 @@ class APIObject(dict):
     the appropriate Python models.
     """
     __api_client = None
+    __resource_path = None
     __response = None
     __pagination = None
     __warnings = None
 
     def __init__(self, api_client, response=None, pagination=None, warnings=None):
         self.__api_client = api_client
+        if response:
+            self.__resource_path = urlsplit(response.url).path
         self.__response = response
         self.__pagination = pagination
         self.__warnings = warnings
@@ -51,6 +56,10 @@ class APIObject(dict):
     @property
     def api_client(self):
         return self.__api_client
+
+    @property
+    def resource_path(self):
+        return self.__resource_path
 
     @property
     def response(self):

--- a/tests/test_api_object.py
+++ b/tests/test_api_object.py
@@ -6,10 +6,10 @@ from __future__ import unicode_literals
 
 import copy
 import json
+from requests.models import Response
 import six
 import unittest2
 import warnings
-from requests.models import Response
 
 from coinbase.wallet.model import APIObject
 from coinbase.wallet.model import new_api_object

--- a/tests/test_api_object.py
+++ b/tests/test_api_object.py
@@ -9,6 +9,7 @@ import json
 import six
 import unittest2
 import warnings
+from requests.models import Response
 
 from coinbase.wallet.model import APIObject
 from coinbase.wallet.model import new_api_object
@@ -54,7 +55,7 @@ class TestNewApiObject(unittest2.TestCase):
         self.assertIsNone(obj.pagination)
         self.assertIsNone(obj.warnings)
 
-        def response(x): return x
+        response = Response()
 
         def pagination(x): return x
 


### PR DESCRIPTION
This offers a possible resolution to the issue described in #83.

I fixed a unit test that this change broke, but in the process I realized that many of the unit tests in this library seem to be broken. The other pieces that are still broken should not be related to my changes because they happen in `master` as well, mostly just `ImportError: cannot import name DependencyWarning`. I will try to find some time to take a closer look at those later. Let me know what I can do if this is not up to snuff @sds :)